### PR TITLE
feat: add laravel 13 support, drop laravel 10

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,16 +17,16 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.4]
-        laravel: [12.*, 11.*, 10.*]
+        php: [8.4, 8.5]
+        laravel: [13.*, 12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*
             testbench: ^9.5
-          - laravel: 10.*
-            testbench: 8.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^10.0||^11.0||^12.0",
-        "saloonphp/laravel-plugin": "^3.0",
+        "illuminate/contracts": "^11.0||^12.0||^13.0",
+        "saloonphp/laravel-plugin": "^3.11",
         "saloonphp/rate-limit-plugin": "^2.0",
         "saloonphp/saloon": "^3.0",
         "spatie/laravel-data": "^4.13",
@@ -28,14 +28,13 @@
         "laravel/pint": "^1.14",
         "larastan/larastan": "^2.9||^3.0",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
-        "orchestra/testbench": "^10.0.0||^9.5.0||^8.22.0",
-        "pestphp/pest": "^2.34|^3.7",
-        "pestphp/pest-plugin-arch": "^2.7|^3",
-        "pestphp/pest-plugin-laravel": "^2.3|^3.1",
+        "orchestra/testbench": "^11.0.0||^10.0.0||^9.5.0",
+        "pestphp/pest": "^2.34|^3.7|^4.0",
+        "pestphp/pest-plugin-arch": "^2.7|^3|^4.0",
+        "pestphp/pest-plugin-laravel": "^2.3|^3.1|^4.1",
         "phpstan/extension-installer": "^1.3||^2.0",
         "phpstan/phpstan-deprecation-rules": "^1.1||^2.0",
-        "phpstan/phpstan-phpunit": "^1.3||^2.0",
-        "spatie/laravel-ray": "^1.35"
+        "phpstan/phpstan-phpunit": "^1.3||^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Description

Adds support for Laravel 13 and drops Laravel 10 support. Updates `illuminate/contracts` to include `^13.0`, updates `orchestra/testbench` dev dependency to include `^11.0.0`, and adds Laravel 13 to the CI test matrix.

## Visual changes

None.

## Include translations

- [ ] Language files have been updated.

## Functional changes

- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.