### PR TITLE
feat: upgrade saloon to v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
     "require": {
         "php": "^8.2",
         "illuminate/contracts": "^11.0||^12.0||^13.0",
-        "saloonphp/laravel-plugin": "^3.11",
+        "saloonphp/laravel-plugin": "^4.0",
         "saloonphp/rate-limit-plugin": "^2.0",
-        "saloonphp/saloon": "^3.0",
+        "saloonphp/saloon": "^4.0",
         "spatie/laravel-data": "^4.13",
         "spatie/laravel-package-tools": "^1.16"
     },

--- a/src/Casts/MoneybirdAuth.php
+++ b/src/Casts/MoneybirdAuth.php
@@ -2,31 +2,48 @@
 
 namespace Sensson\Moneybird\Casts;
 
+use DateTimeImmutable;
 use Saloon\Http\Auth\AccessTokenAuthenticator;
 
 class MoneybirdAuth
 {
-    /**
-     * Cast the given value.
-     */
     public function get($model, string $key, $value, array $attributes): ?AccessTokenAuthenticator
     {
         if (is_null($value)) {
             return null;
         }
 
-        return unserialize($value, ['allowed_classes' => true]);
+        $data = json_decode($value, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            $legacy = unserialize($value, [
+                'allowed_classes' => [AccessTokenAuthenticator::class, DateTimeImmutable::class],
+            ]);
+
+            return new AccessTokenAuthenticator(
+                accessToken: $legacy->getAccessToken(),
+                refreshToken: $legacy->getRefreshToken(),
+                expiresAt: $legacy->getExpiresAt(),
+            );
+        }
+
+        return new AccessTokenAuthenticator(
+            accessToken: $data['access_token'],
+            refreshToken: $data['refresh_token'] ?? null,
+            expiresAt: isset($data['expires_at']) ? new DateTimeImmutable($data['expires_at']) : null,
+        );
     }
 
-    /**
-     * Prepare the given value for storage.
-     */
     public function set($model, string $key, $value, array $attributes): mixed
     {
         if (is_null($value)) {
             return null;
         }
 
-        return serialize($value);
+        return json_encode([
+            'access_token' => $value->getAccessToken(),
+            'refresh_token' => $value->getRefreshToken(),
+            'expires_at' => $value->getExpiresAt()?->format(DateTimeImmutable::ATOM),
+        ]);
     }
 }

--- a/tests/Connectors/MoneybirdConnectorTest.php
+++ b/tests/Connectors/MoneybirdConnectorTest.php
@@ -3,6 +3,7 @@
 use Saloon\Exceptions\Request\Statuses\UnauthorizedException;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
+use Saloon\Traits\Plugins\AcceptsJson;
 use Sensson\Moneybird\Connectors\MoneybirdConnector;
 use Sensson\Moneybird\Exceptions\AccessTokenRevokedException;
 use Sensson\Moneybird\Requests\Administrations\ListAdministrations;
@@ -32,7 +33,7 @@ test('connector accepts json by default', function () {
 
     // Check if the connector uses the AcceptsJson trait
     $traits = class_uses_recursive(get_class($connector));
-    expect($traits)->toContain(\Saloon\Traits\Plugins\AcceptsJson::class);
+    expect($traits)->toContain(AcceptsJson::class);
 });
 
 it('throws AccessTokenRevokedException when access token is revoked', function () {


### PR DESCRIPTION
## Description

Upgrades saloonphp/saloon and saloonphp/laravel-plugin from v3 to v4. Updates the MoneybirdAuth cast to store tokens as JSON instead of PHP serialized data, with backwards compatibility for existing serialized values.

## Visual changes

None.

## Include translations

- [ ] Language files have been updated.

## Functional changes

- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.