### PR TITLE
feat: add financial mutations resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,80 @@ $customFields = Moneybird::administration($administrationId)
     ->all();
 ```
 
+### Financial Mutations
+
+Get all financial mutations. The list is limited to 100 records and accepts
+an optional Moneybird filter string:
+
+```php
+$administrationId = 'your-administration-id';
+$mutations = Moneybird::administration($administrationId)
+    ->financialMutations()
+    ->all(filter: 'period:this_month,state:unprocessed');
+```
+
+Get a specific financial mutation:
+
+```php
+$mutation = Moneybird::administration($administrationId)
+    ->financialMutations()
+    ->get('financial-mutation-id');
+```
+
+To pull in more than 100 mutations, use synchronization. First retrieve the
+id and version of every mutation matching a filter, then fetch the full
+records in batches of up to 100:
+
+```php
+$versions = Moneybird::administration($administrationId)
+    ->financialMutations()
+    ->synchronization('period:this_month,mutation_type:debit');
+
+$ids = $versions->pluck('id')->take(100)->all();
+
+$mutations = Moneybird::administration($administrationId)
+    ->financialMutations()
+    ->getByIds($ids);
+```
+
+Moneybird does not allow filtering mutations by invoice. To find the mutations
+that paid a sales invoice, inspect the payments on each mutation:
+
+```php
+foreach ($mutations as $mutation) {
+    foreach ($mutation->payments as $payment) {
+        if ($payment->invoice_type === 'SalesInvoice' && $payment->invoice_id === $invoiceId) {
+            // ...
+        }
+    }
+}
+```
+
+Link a booking to a mutation:
+
+```php
+$booking = new Booking([
+    'booking_type' => 'LedgerAccount',
+    'booking_id' => 'ledger-account-id',
+    'price' => '10.00',
+]);
+Moneybird::administration($administrationId)
+    ->financialMutations()
+    ->linkBooking('financial-mutation-id', $booking);
+```
+
+Unlink a booking from a mutation:
+
+```php
+$booking = new Booking([
+    'booking_type' => 'Payment',
+    'booking_id' => 'payment-id',
+]);
+Moneybird::administration($administrationId)
+    ->financialMutations()
+    ->unlinkBooking('financial-mutation-id', $booking);
+```
+
 ### Ledgers
 
 Get all ledgers:

--- a/src/Connectors/MoneybirdConnector.php
+++ b/src/Connectors/MoneybirdConnector.php
@@ -15,6 +15,7 @@ use Sensson\Moneybird\Exceptions\AccessTokenRevokedException;
 use Sensson\Moneybird\Resources\AdministrationResource;
 use Sensson\Moneybird\Resources\ContactResource;
 use Sensson\Moneybird\Resources\CustomFieldResource;
+use Sensson\Moneybird\Resources\FinancialMutationResource;
 use Sensson\Moneybird\Resources\LedgerResource;
 use Sensson\Moneybird\Resources\SalesInvoiceResource;
 use Sensson\Moneybird\Resources\TaxRateResource;
@@ -83,6 +84,11 @@ class MoneybirdConnector extends Connector
     public function ledgers(): LedgerResource
     {
         return new LedgerResource($this);
+    }
+
+    public function financialMutations(): FinancialMutationResource
+    {
+        return new FinancialMutationResource($this);
     }
 
     public function taxRates(): TaxRateResource

--- a/src/Data/Booking.php
+++ b/src/Data/Booking.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Sensson\Moneybird\Data;
+
+use Spatie\LaravelData\Data;
+
+class Booking extends Data
+{
+    public function __construct(
+        public string $booking_type,
+        public ?string $booking_id = null,
+        public ?string $price_base = null,
+        public ?string $price = null,
+        public ?string $description = null,
+        public ?string $payment_batch_identifier = null,
+        public ?string $project_id = null,
+        public bool|string|null $mark_open_sepa_transaction_as_paid = null,
+    ) {
+        //
+    }
+}

--- a/src/Data/FinancialMutation.php
+++ b/src/Data/FinancialMutation.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Sensson\Moneybird\Data;
+
+use Spatie\LaravelData\Attributes\DataCollectionOf;
+use Spatie\LaravelData\Data;
+
+class FinancialMutation extends Data
+{
+    public function __construct(
+        public ?string $id = null,
+        public ?string $administration_id = null,
+        public ?string $amount = null,
+        public ?string $code = null,
+        public ?string $date = null,
+        public ?string $message = null,
+        public ?string $contra_account_name = null,
+        public ?string $contra_account_number = null,
+        public ?string $state = null,
+        public ?string $settlement_state = null,
+        public ?string $amount_open = null,
+        public ?array $sepa_fields = null,
+        public ?string $batch_reference = null,
+        public ?string $financial_account_id = null,
+        public ?string $currency = null,
+        public ?string $original_amount = null,
+        public ?string $created_at = null,
+        public ?string $updated_at = null,
+        public ?int $version = null,
+        public ?string $financial_statement_id = null,
+        public ?string $processed_at = null,
+        public ?string $account_servicer_transaction_id = null,
+        #[DataCollectionOf(Payment::class)]
+        public ?array $payments = null,
+        #[DataCollectionOf(LedgerAccountBooking::class)]
+        public ?array $ledger_account_bookings = null,
+    ) {
+        //
+    }
+}

--- a/src/Data/FinancialMutationVersion.php
+++ b/src/Data/FinancialMutationVersion.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Sensson\Moneybird\Data;
+
+use Spatie\LaravelData\Data;
+
+class FinancialMutationVersion extends Data
+{
+    public function __construct(
+        public ?string $id = null,
+        public ?int $version = null,
+    ) {
+        //
+    }
+}

--- a/src/Data/LedgerAccountBooking.php
+++ b/src/Data/LedgerAccountBooking.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Sensson\Moneybird\Data;
+
+use Spatie\LaravelData\Data;
+
+class LedgerAccountBooking extends Data
+{
+    public function __construct(
+        public ?string $id = null,
+        public ?string $administration_id = null,
+        public ?string $financial_mutation_id = null,
+        public ?string $ledger_account_id = null,
+        public ?string $project_id = null,
+        public ?string $description = null,
+        public ?string $price = null,
+        public ?string $created_at = null,
+        public ?string $updated_at = null,
+    ) {
+        //
+    }
+}

--- a/src/Data/Payment.php
+++ b/src/Data/Payment.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Sensson\Moneybird\Data;
+
+use Spatie\LaravelData\Data;
+
+class Payment extends Data
+{
+    public function __construct(
+        public ?string $id = null,
+        public ?string $administration_id = null,
+        public ?string $invoice_type = null,
+        public ?string $invoice_id = null,
+        public ?string $financial_account_id = null,
+        public ?string $user_id = null,
+        public ?string $payment_transaction_id = null,
+        public ?string $transaction_identifier = null,
+        public ?string $price = null,
+        public ?string $price_base = null,
+        public ?string $payment_date = null,
+        public ?string $credit_invoice_id = null,
+        public ?string $financial_mutation_id = null,
+        public ?string $ledger_account_id = null,
+        public ?string $linked_payment_id = null,
+        public ?string $manual_payment_action = null,
+        public ?string $created_at = null,
+        public ?string $updated_at = null,
+    ) {
+        //
+    }
+}

--- a/src/Requests/FinancialMutations/GetFinancialMutation.php
+++ b/src/Requests/FinancialMutations/GetFinancialMutation.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Sensson\Moneybird\Requests\FinancialMutations;
+
+use JsonException;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+use Sensson\Moneybird\Data\FinancialMutation;
+
+class GetFinancialMutation extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function __construct(protected string $id)
+    {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "financial_mutations/{$this->id}.json";
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function createDtoFromResponse(Response $response): FinancialMutation
+    {
+        return FinancialMutation::from($response->json());
+    }
+}

--- a/src/Requests/FinancialMutations/GetFinancialMutationsByIds.php
+++ b/src/Requests/FinancialMutations/GetFinancialMutationsByIds.php
@@ -37,7 +37,7 @@ class GetFinancialMutationsByIds extends Request implements HasBody
     }
 
     /**
-     * @return array{mixed: FinancialMutation}
+     * @return array<int, FinancialMutation>
      *
      * @throws JsonException
      */

--- a/src/Requests/FinancialMutations/GetFinancialMutationsByIds.php
+++ b/src/Requests/FinancialMutations/GetFinancialMutationsByIds.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Sensson\Moneybird\Requests\FinancialMutations;
+
+use JsonException;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+use Saloon\Traits\Body\HasJsonBody;
+use Sensson\Moneybird\Data\FinancialMutation;
+
+class GetFinancialMutationsByIds extends Request implements HasBody
+{
+    use HasJsonBody;
+
+    protected Method $method = Method::POST;
+
+    /**
+     * @param  array<int, string>  $ids
+     */
+    public function __construct(protected array $ids)
+    {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return 'financial_mutations/synchronization.json';
+    }
+
+    protected function defaultBody(): array
+    {
+        return [
+            'ids' => $this->ids,
+        ];
+    }
+
+    /**
+     * @return array{mixed: FinancialMutation}
+     *
+     * @throws JsonException
+     */
+    public function createDtoFromResponse(Response $response): array
+    {
+        return FinancialMutation::collect($response->json());
+    }
+}

--- a/src/Requests/FinancialMutations/LinkBookingFinancialMutation.php
+++ b/src/Requests/FinancialMutations/LinkBookingFinancialMutation.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Sensson\Moneybird\Requests\FinancialMutations;
+
+use JsonException;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+use Saloon\Traits\Body\HasJsonBody;
+use Sensson\Moneybird\Data\Booking;
+use Sensson\Moneybird\Data\FinancialMutation;
+
+class LinkBookingFinancialMutation extends Request implements HasBody
+{
+    use HasJsonBody;
+
+    protected Method $method = Method::PATCH;
+
+    public function __construct(
+        protected string $id,
+        protected Booking $booking,
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "financial_mutations/{$this->id}/link_booking.json";
+    }
+
+    protected function defaultBody(): array
+    {
+        return collect($this->booking->toArray())
+            ->reject(fn (mixed $value): bool => $value === null)
+            ->toArray();
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function createDtoFromResponse(Response $response): FinancialMutation
+    {
+        return FinancialMutation::from($response->json());
+    }
+}

--- a/src/Requests/FinancialMutations/ListFinancialMutations.php
+++ b/src/Requests/FinancialMutations/ListFinancialMutations.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Sensson\Moneybird\Requests\FinancialMutations;
+
+use JsonException;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+use Sensson\Moneybird\Data\FinancialMutation;
+
+class ListFinancialMutations extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function resolveEndpoint(): string
+    {
+        return 'financial_mutations.json';
+    }
+
+    /**
+     * @return array{mixed: FinancialMutation}
+     *
+     * @throws JsonException
+     */
+    public function createDtoFromResponse(Response $response): array
+    {
+        return FinancialMutation::collect($response->json());
+    }
+}

--- a/src/Requests/FinancialMutations/ListFinancialMutations.php
+++ b/src/Requests/FinancialMutations/ListFinancialMutations.php
@@ -18,7 +18,7 @@ class ListFinancialMutations extends Request
     }
 
     /**
-     * @return array{mixed: FinancialMutation}
+     * @return array<int, FinancialMutation>
      *
      * @throws JsonException
      */

--- a/src/Requests/FinancialMutations/SynchronizeFinancialMutations.php
+++ b/src/Requests/FinancialMutations/SynchronizeFinancialMutations.php
@@ -18,7 +18,7 @@ class SynchronizeFinancialMutations extends Request
     }
 
     /**
-     * @return array{mixed: FinancialMutationVersion}
+     * @return array<int, FinancialMutationVersion>
      *
      * @throws JsonException
      */

--- a/src/Requests/FinancialMutations/SynchronizeFinancialMutations.php
+++ b/src/Requests/FinancialMutations/SynchronizeFinancialMutations.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Sensson\Moneybird\Requests\FinancialMutations;
+
+use JsonException;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+use Sensson\Moneybird\Data\FinancialMutationVersion;
+
+class SynchronizeFinancialMutations extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function resolveEndpoint(): string
+    {
+        return 'financial_mutations/synchronization.json';
+    }
+
+    /**
+     * @return array{mixed: FinancialMutationVersion}
+     *
+     * @throws JsonException
+     */
+    public function createDtoFromResponse(Response $response): array
+    {
+        return FinancialMutationVersion::collect($response->json());
+    }
+}

--- a/src/Requests/FinancialMutations/UnlinkBookingFinancialMutation.php
+++ b/src/Requests/FinancialMutations/UnlinkBookingFinancialMutation.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Sensson\Moneybird\Requests\FinancialMutations;
+
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+use Sensson\Moneybird\Data\Booking;
+
+class UnlinkBookingFinancialMutation extends Request implements HasBody
+{
+    use HasJsonBody;
+
+    protected Method $method = Method::DELETE;
+
+    public function __construct(
+        protected string $id,
+        protected Booking $booking,
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "financial_mutations/{$this->id}/unlink_booking.json";
+    }
+
+    protected function defaultBody(): array
+    {
+        return [
+            'booking_type' => $this->booking->booking_type,
+            'booking_id' => $this->booking->booking_id,
+        ];
+    }
+}

--- a/src/Requests/FinancialMutations/UnlinkBookingFinancialMutation.php
+++ b/src/Requests/FinancialMutations/UnlinkBookingFinancialMutation.php
@@ -28,9 +28,9 @@ class UnlinkBookingFinancialMutation extends Request implements HasBody
 
     protected function defaultBody(): array
     {
-        return [
+        return collect([
             'booking_type' => $this->booking->booking_type,
             'booking_id' => $this->booking->booking_id,
-        ];
+        ])->reject(fn (mixed $value): bool => $value === null)->toArray();
     }
 }

--- a/src/Resources/FinancialMutationResource.php
+++ b/src/Resources/FinancialMutationResource.php
@@ -8,9 +8,12 @@ use Saloon\Exceptions\Request\RequestException;
 use Saloon\Http\BaseResource;
 use Sensson\Moneybird\Data\Booking;
 use Sensson\Moneybird\Data\FinancialMutation;
+use Sensson\Moneybird\Data\FinancialMutationVersion;
 use Sensson\Moneybird\Requests\FinancialMutations\GetFinancialMutation;
+use Sensson\Moneybird\Requests\FinancialMutations\GetFinancialMutationsByIds;
 use Sensson\Moneybird\Requests\FinancialMutations\LinkBookingFinancialMutation;
 use Sensson\Moneybird\Requests\FinancialMutations\ListFinancialMutations;
+use Sensson\Moneybird\Requests\FinancialMutations\SynchronizeFinancialMutations;
 use Sensson\Moneybird\Requests\FinancialMutations\UnlinkBookingFinancialMutation;
 
 class FinancialMutationResource extends BaseResource
@@ -20,16 +23,46 @@ class FinancialMutationResource extends BaseResource
      *
      * @throws RequestException|FatalRequestException
      */
-    public function all(?int $perPage = null, ?int $page = null): Collection
+    public function all(?int $perPage = null, ?int $page = null, ?string $filter = null): Collection
     {
         $request = new ListFinancialMutations;
 
         $query = collect([
             'per_page' => $perPage,
             'page' => $page,
+            'filter' => $filter,
         ])->reject(fn (mixed $value): bool => $value === null);
 
         $request->query()->set($query->toArray());
+
+        return collect($this->connector->send($request)->dtoOrFail());
+    }
+
+    /**
+     * @return Collection<FinancialMutationVersion>
+     *
+     * @throws RequestException|FatalRequestException
+     */
+    public function synchronization(?string $filter = null): Collection
+    {
+        $request = new SynchronizeFinancialMutations;
+
+        if ($filter !== null) {
+            $request->query()->set(['filter' => $filter]);
+        }
+
+        return collect($this->connector->send($request)->dtoOrFail());
+    }
+
+    /**
+     * @param  array<int, string>  $ids
+     * @return Collection<FinancialMutation>
+     *
+     * @throws RequestException|FatalRequestException
+     */
+    public function getByIds(array $ids): Collection
+    {
+        $request = new GetFinancialMutationsByIds($ids);
 
         return collect($this->connector->send($request)->dtoOrFail());
     }

--- a/src/Resources/FinancialMutationResource.php
+++ b/src/Resources/FinancialMutationResource.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Sensson\Moneybird\Resources;
+
+use Illuminate\Support\Collection;
+use Saloon\Exceptions\Request\FatalRequestException;
+use Saloon\Exceptions\Request\RequestException;
+use Saloon\Http\BaseResource;
+use Sensson\Moneybird\Data\Booking;
+use Sensson\Moneybird\Data\FinancialMutation;
+use Sensson\Moneybird\Requests\FinancialMutations\GetFinancialMutation;
+use Sensson\Moneybird\Requests\FinancialMutations\LinkBookingFinancialMutation;
+use Sensson\Moneybird\Requests\FinancialMutations\ListFinancialMutations;
+use Sensson\Moneybird\Requests\FinancialMutations\UnlinkBookingFinancialMutation;
+
+class FinancialMutationResource extends BaseResource
+{
+    /**
+     * @return Collection<FinancialMutation>
+     *
+     * @throws RequestException|FatalRequestException
+     */
+    public function all(?int $perPage = null, ?int $page = null): Collection
+    {
+        $request = new ListFinancialMutations;
+
+        $query = collect([
+            'per_page' => $perPage,
+            'page' => $page,
+        ])->reject(fn (mixed $value): bool => $value === null);
+
+        $request->query()->set($query->toArray());
+
+        return collect($this->connector->send($request)->dtoOrFail());
+    }
+
+    /**
+     * @throws RequestException|FatalRequestException
+     */
+    public function get(string $id): FinancialMutation
+    {
+        return $this->connector->send(new GetFinancialMutation($id))->dtoOrFail();
+    }
+
+    /**
+     * @throws RequestException|FatalRequestException
+     */
+    public function linkBooking(string $id, Booking $booking): FinancialMutation
+    {
+        $request = new LinkBookingFinancialMutation($id, $booking);
+
+        return $this->connector->send($request)->dtoOrFail();
+    }
+
+    /**
+     * @throws RequestException|FatalRequestException
+     */
+    public function unlinkBooking(string $id, Booking $booking): void
+    {
+        $request = new UnlinkBookingFinancialMutation($id, $booking);
+
+        $this->connector->send($request);
+    }
+}

--- a/tests/Resources/FinancialMutationResourceTest.php
+++ b/tests/Resources/FinancialMutationResourceTest.php
@@ -1,0 +1,130 @@
+<?php
+
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Sensson\Moneybird\Connectors\MoneybirdConnector;
+use Sensson\Moneybird\Data\Booking;
+use Sensson\Moneybird\Requests\FinancialMutations\GetFinancialMutation;
+use Sensson\Moneybird\Requests\FinancialMutations\LinkBookingFinancialMutation;
+use Sensson\Moneybird\Requests\FinancialMutations\ListFinancialMutations;
+use Sensson\Moneybird\Requests\FinancialMutations\UnlinkBookingFinancialMutation;
+use Sensson\Moneybird\Resources\FinancialMutationResource;
+
+test('financial mutation resource is instantiated correctly', function () {
+    $connector = new MoneybirdConnector;
+    $resource = $connector->financialMutations();
+
+    expect($resource)->toBeInstanceOf(FinancialMutationResource::class);
+});
+
+test('all() calls the list financial mutations request', function () {
+    $mockClient = new MockClient([
+        ListFinancialMutations::class => MockResponse::make([]),
+    ]);
+
+    $connector = (new MoneybirdConnector)->withMockClient($mockClient);
+
+    (new FinancialMutationResource($connector))->all();
+
+    $mockClient->assertSent(ListFinancialMutations::class);
+});
+
+it('passes pagination parameters to all()', function () {
+    $mockClient = new MockClient([
+        ListFinancialMutations::class => MockResponse::make([]),
+    ]);
+
+    $connector = (new MoneybirdConnector)->withMockClient($mockClient);
+
+    (new FinancialMutationResource($connector))->all(perPage: 10, page: 2);
+
+    $mockClient->assertSent(function (ListFinancialMutations $request) {
+        $query = $request->query()->all();
+
+        return $query['per_page'] === 10 && $query['page'] === 2;
+    });
+});
+
+test('get() calls the get financial mutation request', function () {
+    $mockClient = new MockClient([
+        GetFinancialMutation::class => MockResponse::make([
+            'id' => '123456',
+            'amount' => '100.00',
+            'state' => 'unprocessed',
+        ]),
+    ]);
+
+    $connector = (new MoneybirdConnector)->withMockClient($mockClient);
+
+    (new FinancialMutationResource($connector))->get('123456');
+
+    $mockClient->assertSent(GetFinancialMutation::class);
+});
+
+test('linkBooking() calls the link booking request', function () {
+    $mockClient = new MockClient([
+        LinkBookingFinancialMutation::class => MockResponse::make([
+            'id' => '123456',
+            'state' => 'processed',
+        ]),
+    ]);
+
+    $connector = (new MoneybirdConnector)->withMockClient($mockClient);
+
+    $booking = Booking::from([
+        'booking_type' => 'LedgerAccount',
+        'booking_id' => '654321',
+        'price' => '100.00',
+    ]);
+
+    (new FinancialMutationResource($connector))->linkBooking('123456', $booking);
+
+    $mockClient->assertSent(function (LinkBookingFinancialMutation $request) {
+        $body = $request->body()->all();
+
+        return $body['booking_type'] === 'LedgerAccount'
+            && $body['booking_id'] === '654321'
+            && $body['price'] === '100.00';
+    });
+});
+
+it('rejects null parameters from the link booking body', function () {
+    $mockClient = new MockClient([
+        LinkBookingFinancialMutation::class => MockResponse::make(['id' => '123456']),
+    ]);
+
+    $connector = (new MoneybirdConnector)->withMockClient($mockClient);
+
+    $booking = Booking::from([
+        'booking_type' => 'Payment',
+        'booking_id' => '654321',
+    ]);
+
+    (new FinancialMutationResource($connector))->linkBooking('123456', $booking);
+
+    $mockClient->assertSent(function (LinkBookingFinancialMutation $request) {
+        return ! array_key_exists('price', $request->body()->all())
+            && ! array_key_exists('description', $request->body()->all());
+    });
+});
+
+test('unlinkBooking() calls the unlink booking request', function () {
+    $mockClient = new MockClient([
+        UnlinkBookingFinancialMutation::class => MockResponse::make([], 200),
+    ]);
+
+    $connector = (new MoneybirdConnector)->withMockClient($mockClient);
+
+    $booking = Booking::from([
+        'booking_type' => 'Payment',
+        'booking_id' => '654321',
+    ]);
+
+    (new FinancialMutationResource($connector))->unlinkBooking('123456', $booking);
+
+    $mockClient->assertSent(function (UnlinkBookingFinancialMutation $request) {
+        $body = $request->body()->all();
+
+        return $body['booking_type'] === 'Payment' && $body['booking_id'] === '654321';
+    });
+});

--- a/tests/Resources/FinancialMutationResourceTest.php
+++ b/tests/Resources/FinancialMutationResourceTest.php
@@ -4,6 +4,9 @@ use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 use Sensson\Moneybird\Connectors\MoneybirdConnector;
 use Sensson\Moneybird\Data\Booking;
+use Sensson\Moneybird\Data\FinancialMutation;
+use Sensson\Moneybird\Data\LedgerAccountBooking;
+use Sensson\Moneybird\Data\Payment;
 use Sensson\Moneybird\Requests\FinancialMutations\GetFinancialMutation;
 use Sensson\Moneybird\Requests\FinancialMutations\GetFinancialMutationsByIds;
 use Sensson\Moneybird\Requests\FinancialMutations\LinkBookingFinancialMutation;
@@ -171,4 +174,77 @@ test('unlinkBooking() calls the unlink booking request', function () {
 
         return $body['booking_type'] === 'Payment' && $body['booking_id'] === '654321';
     });
+});
+
+it('omits a null booking id from the unlink booking body', function () {
+    $mockClient = new MockClient([
+        UnlinkBookingFinancialMutation::class => MockResponse::make([], 200),
+    ]);
+
+    $connector = (new MoneybirdConnector)->withMockClient($mockClient);
+
+    $booking = Booking::from(['booking_type' => 'Payment']);
+
+    (new FinancialMutationResource($connector))->unlinkBooking('123456', $booking);
+
+    $mockClient->assertSent(function (UnlinkBookingFinancialMutation $request) {
+        return ! array_key_exists('booking_id', $request->body()->all());
+    });
+});
+
+test('synchronization() works without a filter', function () {
+    $mockClient = new MockClient([
+        SynchronizeFinancialMutations::class => MockResponse::make([]),
+    ]);
+
+    $connector = (new MoneybirdConnector)->withMockClient($mockClient);
+
+    (new FinancialMutationResource($connector))->synchronization();
+
+    $mockClient->assertSent(function (SynchronizeFinancialMutations $request) {
+        return $request->query()->all() === [];
+    });
+});
+
+test('linkBooking() returns a financial mutation', function () {
+    $mockClient = new MockClient([
+        LinkBookingFinancialMutation::class => MockResponse::make([
+            'id' => '123456',
+            'state' => 'processed',
+        ]),
+    ]);
+
+    $connector = (new MoneybirdConnector)->withMockClient($mockClient);
+
+    $booking = Booking::from(['booking_type' => 'LedgerAccount', 'booking_id' => '654321']);
+
+    $mutation = (new FinancialMutationResource($connector))->linkBooking('123456', $booking);
+
+    expect($mutation)->toBeInstanceOf(FinancialMutation::class)
+        ->and($mutation->id)->toBe('123456')
+        ->and($mutation->state)->toBe('processed');
+});
+
+test('get() hydrates nested payments and ledger account bookings', function () {
+    $mockClient = new MockClient([
+        GetFinancialMutation::class => MockResponse::make([
+            'id' => '123456',
+            'amount' => '100.00',
+            'payments' => [
+                ['id' => 'p1', 'invoice_type' => 'SalesInvoice', 'invoice_id' => 'inv1'],
+            ],
+            'ledger_account_bookings' => [
+                ['id' => 'b1', 'ledger_account_id' => 'la1', 'price' => '100.00'],
+            ],
+        ]),
+    ]);
+
+    $connector = (new MoneybirdConnector)->withMockClient($mockClient);
+
+    $mutation = (new FinancialMutationResource($connector))->get('123456');
+
+    expect($mutation->payments[0])->toBeInstanceOf(Payment::class)
+        ->and($mutation->payments[0]->invoice_id)->toBe('inv1')
+        ->and($mutation->ledger_account_bookings[0])->toBeInstanceOf(LedgerAccountBooking::class)
+        ->and($mutation->ledger_account_bookings[0]->ledger_account_id)->toBe('la1');
 });

--- a/tests/Resources/FinancialMutationResourceTest.php
+++ b/tests/Resources/FinancialMutationResourceTest.php
@@ -5,8 +5,10 @@ use Saloon\Http\Faking\MockResponse;
 use Sensson\Moneybird\Connectors\MoneybirdConnector;
 use Sensson\Moneybird\Data\Booking;
 use Sensson\Moneybird\Requests\FinancialMutations\GetFinancialMutation;
+use Sensson\Moneybird\Requests\FinancialMutations\GetFinancialMutationsByIds;
 use Sensson\Moneybird\Requests\FinancialMutations\LinkBookingFinancialMutation;
 use Sensson\Moneybird\Requests\FinancialMutations\ListFinancialMutations;
+use Sensson\Moneybird\Requests\FinancialMutations\SynchronizeFinancialMutations;
 use Sensson\Moneybird\Requests\FinancialMutations\UnlinkBookingFinancialMutation;
 use Sensson\Moneybird\Resources\FinancialMutationResource;
 
@@ -29,20 +31,62 @@ test('all() calls the list financial mutations request', function () {
     $mockClient->assertSent(ListFinancialMutations::class);
 });
 
-it('passes pagination parameters to all()', function () {
+it('passes pagination and filter parameters to all()', function () {
     $mockClient = new MockClient([
         ListFinancialMutations::class => MockResponse::make([]),
     ]);
 
     $connector = (new MoneybirdConnector)->withMockClient($mockClient);
 
-    (new FinancialMutationResource($connector))->all(perPage: 10, page: 2);
+    (new FinancialMutationResource($connector))->all(perPage: 10, page: 2, filter: 'period:this_month');
 
     $mockClient->assertSent(function (ListFinancialMutations $request) {
         $query = $request->query()->all();
 
-        return $query['per_page'] === 10 && $query['page'] === 2;
+        return $query['per_page'] === 10
+            && $query['page'] === 2
+            && $query['filter'] === 'period:this_month';
     });
+});
+
+test('synchronization() calls the synchronize request', function () {
+    $mockClient = new MockClient([
+        SynchronizeFinancialMutations::class => MockResponse::make([
+            ['id' => '123456', 'version' => 3],
+            ['id' => '654321', 'version' => 1],
+        ]),
+    ]);
+
+    $connector = (new MoneybirdConnector)->withMockClient($mockClient);
+
+    $versions = (new FinancialMutationResource($connector))->synchronization('period:this_month');
+
+    $mockClient->assertSent(function (SynchronizeFinancialMutations $request) {
+        return $request->query()->all()['filter'] === 'period:this_month';
+    });
+
+    expect($versions)->toHaveCount(2)
+        ->and($versions->first()->id)->toBe('123456')
+        ->and($versions->first()->version)->toBe(3);
+});
+
+test('getByIds() calls the synchronization batch request', function () {
+    $mockClient = new MockClient([
+        GetFinancialMutationsByIds::class => MockResponse::make([
+            ['id' => '123456', 'amount' => '100.00'],
+        ]),
+    ]);
+
+    $connector = (new MoneybirdConnector)->withMockClient($mockClient);
+
+    $mutations = (new FinancialMutationResource($connector))->getByIds(['123456', '654321']);
+
+    $mockClient->assertSent(function (GetFinancialMutationsByIds $request) {
+        return $request->body()->all()['ids'] === ['123456', '654321'];
+    });
+
+    expect($mutations)->toHaveCount(1)
+        ->and($mutations->first()->id)->toBe('123456');
 });
 
 test('get() calls the get financial mutation request', function () {


### PR DESCRIPTION
## Description

Adds support for the Moneybird [Financial Mutations API](https://developer.moneybird.com/api/financial-mutations). Financial mutations are the individual transactions imported from a financial account (bank/credit card); this resource lets you list them, fetch one by id, and link or unlink bookings (payments or ledger account bookings) to process them.

Accessed via the connector:

```php
$connector->financialMutations()->all(perPage: 50, page: 1);
$connector->financialMutations()->get($id);

$booking = Booking::from([
    'booking_type' => 'LedgerAccount',
    'booking_id' => $ledgerAccountId,
    'price' => '10.00',
]);
$connector->financialMutations()->linkBooking($id, $booking);
$connector->financialMutations()->unlinkBooking($id, $booking);
```

Following the existing resource style, `linkBooking`/`unlinkBooking` take a `Booking` data object rather than a long argument list. All DTO field names and types were verified against the authoritative `moneybird/openapi` spec.

`all()` also accepts a Moneybird `filter` string, and the bulk `synchronization` endpoints are included (`synchronization()` for id/version pairs and `getByIds()` to fetch full records in batches) for pulling more than 100 mutations.

## Visual changes

None.

## Include translations

- [ ] Language files have been updated.

## Functional changes

- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
